### PR TITLE
.gitignoreにビルドバイナリファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # バイナリファイル
 /awsmyinfo
 /bin/
+awsmyinfo-*
 
 # Mac OSのファイル
 .DS_Store


### PR DESCRIPTION
## 概要
リリース用にビルドしたバイナリファイルが未追跡ファイルとして残っていたため、.gitignoreに追加して今後無視されるようにしました。

## 背景
リリース時にマルチプラットフォーム向けバイナリ（awsmyinfo-darwin-amd64、awsmyinfo-darwin-arm64、awsmyinfo-linux-amd64）をビルドしましたが、これらがGitで未追跡ファイルとして表示されており、リポジトリを汚している状態でした。

## 内容詳細
- .gitignoreに`awsmyinfo-*`パターンを追加
- これによりビルドされたバイナリファイルが自動的に無視される

## レビューポイント
- .gitignoreの追加内容が適切かどうか
- 他に無視すべきファイルパターンがないかどうか

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ignored files to include all items starting with `awsmyinfo-`, ensuring broader exclusion of related files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->