### PR TITLE
--versionフラグを追加してバージョン情報表示機能を実装

### DIFF
--- a/cmd/awsmyinfo/main.go
+++ b/cmd/awsmyinfo/main.go
@@ -9,9 +9,18 @@ import (
 	"github.com/juliar13/awsmyinfo/pkg/aws"
 )
 
+const version = "0.1.0"
+
 func main() {
 	// フラグの設定
+	var showVersion = flag.Bool("version", false, "バージョン情報を表示")
 	flag.Parse()
+
+	// バージョン情報の表示
+	if *showVersion {
+		fmt.Printf("awsmyinfo version %s\n", version)
+		return
+	}
 
 	// コンテキストの作成
 	ctx := context.Background()


### PR DESCRIPTION
## 概要
`awsmyinfo --version` コマンドでバージョン情報を表示できる機能を追加しました。

## 背景
CLIツールの標準的な機能として、バージョン確認コマンドが必要でした。Homebrew Formulaのテストでも `--version` フラグが使用されているため、実装が必要でした。

## 内容詳細
- `--version` フラグを追加（`flag.Bool` を使用）
- バージョン定数 `const version = "0.1.0"` を定義
- フラグが指定された場合は `awsmyinfo version 0.1.0` を表示して終了
- 既存の機能には影響なし

## テスト結果
```bash
$ ./awsmyinfo --version
awsmyinfo version 0.1.0
```

## レビューポイント
- バージョン定数の管理方法が適切かどうか
- フラグの実装方法が標準的かどうか
- 出力フォーマットが適切かどうか

🤖 Generated with [Claude Code](https://claude.ai/code)